### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://simplecodewriter.visualstudio.com/6a1f5346-c4cc-4d02-a975-7cc8c73739de/839d9126-8a0b-402f-a43a-1cbf8beb9207/_apis/work/boardbadge/b74f3071-164d-4ea7-892e-62417c3bc547)](https://simplecodewriter.visualstudio.com/6a1f5346-c4cc-4d02-a975-7cc8c73739de/_boards/board/t/839d9126-8a0b-402f-a43a-1cbf8beb9207/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#20. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.